### PR TITLE
fix: figure out prefix size dynamically

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,9 +175,9 @@ func untestedSections(coverageFilePath string) (sections []Section) {
 }
 
 func normalizeModulePath(path string, workingDirectory string) (displayPath string, readPath string) {
-	modulePrefixSize := 3 // foo.com/bar/baz + file.go
 	separator := string(os.PathSeparator)
-	parts := strings.SplitN(path, separator, modulePrefixSize+1)
+	parts := strings.Split(path, separator)
+	modulePrefixSize := len(parts) - 1
 	goPath, hasGoPath := os.LookupEnv("GOPATH")
 	inGoPath := false
 	goPrefixedPath := joinPath(goPath, "src", path)


### PR DESCRIPTION
addresses https://github.com/grosser/go-testcov/issues/14
```
[~/Code/public/cluster-logging-operator/internal/metrics (master)] ➔ go-testcov .
ok  	github.com/openshift/cluster-logging-operator/internal/metrics	0.464s	coverage: 81.8% of statements
dashboards.go new untested sections introduced (2 current vs 0 configured)
dashboards.go:25.16,27.3
dashboards.go:43.99,45.3
```

i didn't really understand the logic behind the static prefixSize of 3 but monkeyed around a fix. I also tested against my private repo in gitlab and it worked there too.

against the public test repo above:

the raw path is `github.com/openshift/cluster-logging-operator/internal/metrics/dashboards.go`

prefix = 3
parts = [github.com openshift cluster-logging-operator internal/metrics/dashboards.go]

prefix = 5 (works)
parts = [github.com openshift cluster-logging-operator internal metrics dashboards.go]

count of split by "/" returns 6. so -1 to get 5. 

cc @grosser 