### PR TITLE
feat: ignore blocks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,7 @@
  - Onboard untested code (top of the file `// untested sections: 5` comment, warns when below)
  - Ignore untested files (top of the file `// untested sections: ignore` comment)
  - Ignore large amounts of poorly tested code (top of the file `// untested sections: 50%` comment, does not warn when below that %)
+ - Ignore untested functions with `// untested section` comment in function header
  - Run `ginkgo` with `go-testcov ginkgo ./...`
 
 ```
@@ -32,7 +33,7 @@ pkg.go:54.5,56.5
  - `go-testcov version` to see current version
 
 
-## Makefile setup
+## Makefile setup to use a consistent version of go-testcov
 
 ```
 .PHONY: test
@@ -108,6 +109,11 @@ make
 - the files from the root folder are symlinked there to make everything load
 - easiest to work from that folder directly
 
+### inspecting coverage output
+
+- create a new `foo/main.go` file with the code you want to inspect
+- `go test -cover -coverprofile cov.out foo/main.go`
+- `cat cov.out`
 
 ## Release
 

--- a/bar/main.go
+++ b/bar/main.go
@@ -1,0 +1,14 @@
+package main
+
+import "os"
+
+// some other stuff
+// even more
+// untested section
+func main() {
+	if len(os.Args) < 2 {
+		os.Exit(1)
+	} else {
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION
often 1 whole function is untested, and sprinkling `// untested section` throughout it is a pain,
but the alternative of `// untested sections: 12` is also annoying
.. so mark these with `// untested block` instead
(could not reuse `// untested section` because that is already allowed to be above the untested line